### PR TITLE
Wrong variable type makes vasp fail.

### DIFF
--- a/src/solvation.F
+++ b/src/solvation.F
@@ -3135,8 +3135,8 @@ CONTAINS
              '   NC_K    =',F10.6,  '     cutoff charge density' /&
              '   TAU     =',F10.6,  '     cavity surface tension' /&
              '   LAMBDA_D_K    =',F10.6,  '     Debye length in Angstroms' /&
-             '   LRHOB     =',F10.6,  '     write boundcharge  density' /&
-             '   LRHOION     =',F10.6,  '     write ioniccharge density' /)
+             '   LRHOB     =',L6,  '     write boundcharge  density' /&
+             '   LRHOION     =',L6,  '     write ioniccharge density' /)
 
 
     RETURN


### PR DESCRIPTION
VASP fails with

```
 At line 2825 of file solvation.f90 (unit = 8, file = 'OUTCAR')
Fortran runtime error: Expected REAL for item 7 in formatted transfer, got LOGICAL
troms' /              '   LRHOB     =',F10.6,  '     write boundcharge  density'
```

This patch fixes the expected variable type..